### PR TITLE
Fix hardcoded model embedding size in v1

### DIFF
--- a/alpaca_finetuning_v1/llama/model.py
+++ b/alpaca_finetuning_v1/llama/model.py
@@ -210,7 +210,7 @@ class Transformer(nn.Module):
                 h = layer(h, start_pos, freqs_cis, mask)
 
         adapter_index = 0
-        adapter = self.adapter_query.weight.reshape(-1, self.adapter_len, 4096).unsqueeze(1)
+        adapter = self.adapter_query.weight.reshape(-1, self.adapter_len, self.params.dim).unsqueeze(1)
         for layer in self.layers[-1 * self.adapter_layer :]:
             h = layer(h, start_pos, freqs_cis, mask, adapter[adapter_index].half())
             adapter_index = adapter_index + 1


### PR DESCRIPTION
Seems this was fixed in v2 (probably since larger models were used and this bug was identified) but I noticed it still existed in v1.

Great work by the way.